### PR TITLE
Chore: Use vanity address for yarn tests (#8)

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,5 +1,5 @@
 [programs.localnet]
-monaco_protocol = "4UqmjWpDxXA7jgmfDYxmxj4fYrPCEXMRn95nJ3Uko9Ay"
+monaco_protocol = "monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih"
 
 [registry]
 url = "https://anchor.projectserum.com"


### PR DESCRIPTION
* chore: use single program id
* use monaco for localnet, keep other ids