### PR TITLE
fix: source liquidity rounded down to avoid underfunding

### DIFF
--- a/programs/monaco_protocol/src/instructions/market_liquidities/update_market_liquidities_with_cross_liquidity.rs
+++ b/programs/monaco_protocol/src/instructions/market_liquidities/update_market_liquidities_with_cross_liquidity.rs
@@ -80,7 +80,7 @@ mod test {
         .expect("update_market_liquidities_with_cross_liquidity failed");
 
         assert_eq!(
-            vec!((1, 1.5, 2000), (1, 1.4, 2500), (1, 1.32, 3125)),
+            vec!((1, 1.5, 2000), (1, 1.4, 2000), (1, 1.32, 3000)),
             liquidities(&market_liquidities.liquidities_against)
         );
     }
@@ -90,12 +90,18 @@ mod test {
         // 2.0, 3.0, 6.0
         // 2.1, 3.0, 5.25
         let mut market_liquidities = mock_market_liquidities(Pubkey::new_unique());
-        market_liquidities.add_liquidity_for(0, 2.0, 100).unwrap();
-        market_liquidities.add_liquidity_for(0, 2.1, 100).unwrap();
-        market_liquidities.add_liquidity_for(1, 3.0, 100).unwrap();
+        market_liquidities
+            .add_liquidity_for(0, 2.0, 100_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(0, 2.1, 100_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 3.0, 100_000)
+            .unwrap();
 
         assert_eq!(
-            vec!((0, 2.0, 100), (0, 2.1, 100), (1, 3.0, 100)),
+            vec!((0, 2.0, 100_000), (0, 2.1, 100_000), (1, 3.0, 100_000)),
             liquidities(&market_liquidities.liquidities_for)
         );
 
@@ -117,7 +123,7 @@ mod test {
         .expect("update_market_liquidities_with_cross_liquidity failed");
 
         assert_eq!(
-            vec!((2, 6.0, 33), (2, 5.25, 40)),
+            vec!((2, 6.0, 33_000), (2, 5.25, 40_000)),
             liquidities(&market_liquidities.liquidities_against)
         );
     }

--- a/programs/monaco_protocol/src/instructions/matching/on_order_creation.rs
+++ b/programs/monaco_protocol/src/instructions/matching/on_order_creation.rs
@@ -292,14 +292,14 @@ mod test_match_for_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 1, true, 2.8, 100, payer_pk);
+        let mut order = mock_order(market_pk, 1, true, 2.8, 100_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
         market_liquidities
-            .add_liquidity_against(1, 2.8, 125)
+            .add_liquidity_against(1, 2.8, 125_000)
             .unwrap();
         market_liquidities
-            .add_liquidity_against(2, 2.8, 125)
+            .add_liquidity_against(2, 2.8, 125_000)
             .unwrap();
         market_liquidities.update_cross_liquidity_for(&[
             LiquiditySource::new(1, 2.8),
@@ -320,20 +320,20 @@ mod test_match_for_order {
         .expect("match_for_order");
 
         assert_eq!(
-            vec!((3.5, 100)), // TODO incorrect - should be 20
+            vec!((3.5, 100_000)), // TODO incorrect - should be 20
             liquidities(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec!((2.8, 125), (2.8, 25)),
+            vec!((2.8, 125_000), (2.8, 25_000)),
             liquidities(&market_liquidities.liquidities_against)
         );
         assert_eq!(
-            vec![(false, 2.8, 100), (true, 2.8, 100),],
+            vec![(false, 2.8, 100_000), (true, 2.8, 100_000),],
             matches(&market_matching_queue.matches)
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(280_u64, order.payout);
+        assert_eq!(280_000_u64, order.payout);
     }
 
     #[test]
@@ -342,11 +342,15 @@ mod test_match_for_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 0, true, 3.5, 80, payer_pk);
+        let mut order = mock_order(market_pk, 0, true, 3.5, 80_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        market_liquidities.add_liquidity_for(1, 2.8, 125).unwrap();
-        market_liquidities.add_liquidity_for(2, 2.8, 125).unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 2.8, 125_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(2, 2.8, 125_000)
+            .unwrap();
         market_liquidities.update_cross_liquidity_against(&[
             LiquiditySource::new(1, 2.8),
             LiquiditySource::new(2, 2.8),
@@ -366,20 +370,24 @@ mod test_match_for_order {
         .expect("match_for_order");
 
         assert_eq!(
-            vec![(2.8, 25), (2.8, 25)],
+            vec![(2.8, 25_000), (2.8, 25_000)],
             liquidities(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec![(3.5, "2.80:2.80".to_string(), 20)],
+            vec![(3.5, "2.80:2.80".to_string(), 20_000)],
             liquidities2(&market_liquidities.liquidities_against)
         );
         assert_eq!(
-            vec![(true, 2.8, 100), (true, 2.8, 100), (true, 3.5, 80)],
+            vec![
+                (true, 2.8, 100_000),
+                (true, 2.8, 100_000),
+                (true, 3.5, 80_000)
+            ],
             matches(&market_matching_queue.matches) // vec max length
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(280_u64, order.payout);
+        assert_eq!(280_000_u64, order.payout);
     }
 
     #[test]
@@ -388,21 +396,25 @@ mod test_match_for_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 0, true, 3.5, 80, payer_pk);
+        let mut order = mock_order(market_pk, 0, true, 3.5, 80_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        market_liquidities.add_liquidity_for(1, 2.8, 250).unwrap();
-        market_liquidities.add_liquidity_for(2, 2.8, 250).unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 2.8, 250_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(2, 2.8, 250_000)
+            .unwrap();
         market_liquidities.update_cross_liquidity_against(&[
             LiquiditySource::new(1, 2.8),
             LiquiditySource::new(2, 2.8),
         ]);
         // following removals make cross liquidity to be too big
         market_liquidities
-            .remove_liquidity_for(1, 2.8, 125)
+            .remove_liquidity_for(1, 2.8, 125_000)
             .unwrap();
         market_liquidities
-            .remove_liquidity_for(2, 2.8, 125)
+            .remove_liquidity_for(2, 2.8, 125_000)
             .unwrap();
 
         let mut market_matching_queue = MarketMatchingQueue {
@@ -419,20 +431,24 @@ mod test_match_for_order {
         .expect("match_for_order");
 
         assert_eq!(
-            vec![(2.8, "".to_string(), 25), (2.8, "".to_string(), 25)],
+            vec![(2.8, "".to_string(), 25_000), (2.8, "".to_string(), 25_000)],
             liquidities2(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec![(3.5, "2.80:2.80".to_string(), 20)],
+            vec![(3.5, "2.80:2.80".to_string(), 20_000)],
             liquidities2(&market_liquidities.liquidities_against)
         );
         assert_eq!(
-            vec![(true, 2.8, 100), (true, 2.8, 100), (true, 3.5, 80)],
+            vec![
+                (true, 2.8, 100_000),
+                (true, 2.8, 100_000),
+                (true, 3.5, 80_000)
+            ],
             matches(&market_matching_queue.matches) // vec max length
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(280_u64, order.payout);
+        assert_eq!(280_000_u64, order.payout);
     }
 
     #[test]
@@ -441,26 +457,30 @@ mod test_match_for_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 0, true, 3.5, 80, payer_pk);
+        let mut order = mock_order(market_pk, 0, true, 3.5, 80_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        market_liquidities.add_liquidity_for(1, 2.8, 125).unwrap();
-        market_liquidities.add_liquidity_for(2, 2.8, 125).unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 2.8, 125_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(2, 2.8, 125_000)
+            .unwrap();
         market_liquidities.update_cross_liquidity_against(&[
             LiquiditySource::new(1, 2.8),
             LiquiditySource::new(2, 2.8),
         ]);
         assert_eq!(
-            vec![(3.5, "2.80:2.80".to_string(), 100)],
+            vec![(3.5, "2.80:2.80".to_string(), 100_000)],
             liquidities2(&market_liquidities.liquidities_against)
         );
 
         // following removals make cross liquidity to be too big
         market_liquidities
-            .remove_liquidity_for(1, 2.8, 125)
+            .remove_liquidity_for(1, 2.8, 125_000)
             .unwrap();
         market_liquidities
-            .remove_liquidity_for(2, 2.8, 125)
+            .remove_liquidity_for(2, 2.8, 125_000)
             .unwrap();
 
         let mut market_matching_queue = MarketMatchingQueue {
@@ -477,7 +497,7 @@ mod test_match_for_order {
         .expect("match_for_order");
 
         assert_eq!(
-            vec![(3.5, "".to_string(), 80)],
+            vec![(3.5, "".to_string(), 80_000)],
             liquidities2(&market_liquidities.liquidities_for)
         );
         assert_eq!(
@@ -489,7 +509,7 @@ mod test_match_for_order {
             matches(&market_matching_queue.matches) // vec max length
         );
 
-        assert_eq!(80_u64, order.stake_unmatched);
+        assert_eq!(80_000_u64, order.stake_unmatched);
         assert_eq!(0_u64, order.payout);
     }
 
@@ -499,12 +519,18 @@ mod test_match_for_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 0, true, 3.0, 120, payer_pk);
+        let mut order = mock_order(market_pk, 0, true, 3.0, 120_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        market_liquidities.add_liquidity_for(1, 3.6, 200).unwrap();
-        market_liquidities.add_liquidity_for(2, 4.0, 180).unwrap();
-        market_liquidities.add_liquidity_for(3, 7.2, 100).unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 3.6, 200_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(2, 4.0, 180_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(3, 7.2, 100_000)
+            .unwrap();
         market_liquidities.update_cross_liquidity_against(&[
             LiquiditySource::new(1, 3.6),
             LiquiditySource::new(2, 4.0),
@@ -525,25 +551,25 @@ mod test_match_for_order {
         .expect("match_for_order");
 
         assert_eq!(
-            vec![(3.6, 100), (4.0, 90), (7.2, 50)],
+            vec![(3.6, 100_000), (4.0, 90_000), (7.2, 50_000)],
             liquidities(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec![(3.0, 120)],
+            vec![(3.0, 120_000)],
             liquidities(&market_liquidities.liquidities_against)
         );
         assert_eq!(
             vec![
-                (true, 3.6, 100),
-                (true, 4.0, 90),
-                (true, 7.2, 50),
-                (true, 3.0, 120)
+                (true, 3.6, 100_000),
+                (true, 4.0, 90_000),
+                (true, 7.2, 50_000),
+                (true, 3.0, 120_000)
             ],
             matches(&market_matching_queue.matches)
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(360_u64, order.payout);
+        assert_eq!(360_000_u64, order.payout);
     }
 }
 
@@ -562,11 +588,15 @@ mod test_match_against_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 1, false, 2.8, 100, payer_pk);
+        let mut order = mock_order(market_pk, 1, false, 2.8, 100_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        market_liquidities.add_liquidity_for(1, 2.8, 125).unwrap();
-        market_liquidities.add_liquidity_for(2, 2.8, 125).unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 2.8, 125_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(2, 2.8, 125_000)
+            .unwrap();
         market_liquidities.update_cross_liquidity_against(&[
             LiquiditySource::new(1, 2.8),
             LiquiditySource::new(2, 2.8),
@@ -586,20 +616,20 @@ mod test_match_against_order {
         .expect("");
 
         assert_eq!(
-            vec!((2.8, 25), (2.8, 125)),
+            vec!((2.8, 25_000), (2.8, 125_000)),
             liquidities(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec!((3.5, 100)), // TODO incorrect - should be 20
+            vec!((3.5, 100_000)), // TODO incorrect - should be 20
             liquidities(&market_liquidities.liquidities_against)
         );
         assert_eq!(
-            vec![(true, 2.8, 100), (false, 2.8, 100),],
+            vec![(true, 2.8, 100_000), (false, 2.8, 100_000),],
             matches(&market_matching_queue.matches)
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(280_u64, order.payout);
+        assert_eq!(280_000_u64, order.payout);
     }
 
     #[test]
@@ -608,14 +638,14 @@ mod test_match_against_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 0, false, 3.5, 80, payer_pk);
+        let mut order = mock_order(market_pk, 0, false, 3.5, 80_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
         market_liquidities
-            .add_liquidity_against(1, 2.8, 125)
+            .add_liquidity_against(1, 2.8, 125_000)
             .unwrap();
         market_liquidities
-            .add_liquidity_against(2, 2.8, 125)
+            .add_liquidity_against(2, 2.8, 125_000)
             .unwrap();
         market_liquidities.update_cross_liquidity_for(&[
             LiquiditySource::new(1, 2.8),
@@ -636,20 +666,24 @@ mod test_match_against_order {
         .expect("");
 
         assert_eq!(
-            vec!((3.5, 20)),
+            vec!((3.5, 20_000)),
             liquidities(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec![(2.8, 25), (2.8, 25)],
+            vec![(2.8, 25_000), (2.8, 25_000)],
             liquidities(&market_liquidities.liquidities_against)
         );
         assert_eq!(
-            vec![(false, 2.8, 100), (false, 2.8, 100), (false, 3.5, 80)],
+            vec![
+                (false, 2.8, 100_000),
+                (false, 2.8, 100_000),
+                (false, 3.5, 80_000)
+            ],
             matches(&market_matching_queue.matches) // vec max length
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(280_u64, order.payout);
+        assert_eq!(280_000_u64, order.payout);
     }
 
     #[test]
@@ -658,14 +692,14 @@ mod test_match_against_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 0, false, 3.5, 80, payer_pk);
+        let mut order = mock_order(market_pk, 0, false, 3.5, 80_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
         market_liquidities
-            .add_liquidity_against(1, 2.8, 250)
+            .add_liquidity_against(1, 2.8, 250_000)
             .unwrap();
         market_liquidities
-            .add_liquidity_against(2, 2.8, 250)
+            .add_liquidity_against(2, 2.8, 250_000)
             .unwrap();
         market_liquidities.update_cross_liquidity_for(&[
             LiquiditySource::new(1, 2.8),
@@ -673,10 +707,10 @@ mod test_match_against_order {
         ]);
         // following removals make cross liquidity to be too big
         market_liquidities
-            .remove_liquidity_against(1, 2.8, 125)
+            .remove_liquidity_against(1, 2.8, 125_000)
             .unwrap();
         market_liquidities
-            .remove_liquidity_against(2, 2.8, 125)
+            .remove_liquidity_against(2, 2.8, 125_000)
             .unwrap();
 
         let mut market_matching_queue = MarketMatchingQueue {
@@ -693,20 +727,24 @@ mod test_match_against_order {
         .expect("");
 
         assert_eq!(
-            vec![(3.5, "2.80:2.80".to_string(), 20)],
+            vec![(3.5, "2.80:2.80".to_string(), 20_000)],
             liquidities2(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec![(2.8, "".to_string(), 25), (2.8, "".to_string(), 25)],
+            vec![(2.8, "".to_string(), 25_000), (2.8, "".to_string(), 25_000)],
             liquidities2(&market_liquidities.liquidities_against)
         );
         assert_eq!(
-            vec![(false, 2.8, 100), (false, 2.8, 100), (false, 3.5, 80)],
+            vec![
+                (false, 2.8, 100_000),
+                (false, 2.8, 100_000),
+                (false, 3.5, 80_000)
+            ],
             matches(&market_matching_queue.matches) // vec max length
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(280_u64, order.payout);
+        assert_eq!(280_000_u64, order.payout);
     }
 
     #[test]
@@ -772,17 +810,17 @@ mod test_match_against_order {
         let payer_pk = Pubkey::new_unique();
 
         let order_pk = Pubkey::new_unique();
-        let mut order = mock_order(market_pk, 0, false, 3.0, 120, payer_pk);
+        let mut order = mock_order(market_pk, 0, false, 3.0, 120_000, payer_pk);
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
         market_liquidities
-            .add_liquidity_against(1, 3.6, 200)
+            .add_liquidity_against(1, 3.6, 200_000)
             .unwrap();
         market_liquidities
-            .add_liquidity_against(2, 4.0, 180)
+            .add_liquidity_against(2, 4.0, 180_000)
             .unwrap();
         market_liquidities
-            .add_liquidity_against(3, 7.2, 100)
+            .add_liquidity_against(3, 7.2, 100_000)
             .unwrap();
         market_liquidities.update_cross_liquidity_for(&[
             LiquiditySource::new(1, 3.6),
@@ -804,25 +842,25 @@ mod test_match_against_order {
         .expect("");
 
         assert_eq!(
-            vec![(3.0, 120)],
+            vec![(3.0, 120_000)],
             liquidities(&market_liquidities.liquidities_for)
         );
         assert_eq!(
-            vec![(7.2, 50), (4.0, 90), (3.6, 100),],
+            vec![(7.2, 50_000), (4.0, 90_000), (3.6, 100_000),],
             liquidities(&market_liquidities.liquidities_against)
         );
         assert_eq!(
             vec![
-                (false, 3.6, 100),
-                (false, 4.0, 90),
-                (false, 7.2, 50),
-                (false, 3.0, 120)
+                (false, 3.6, 100_000),
+                (false, 4.0, 90_000),
+                (false, 7.2, 50_000),
+                (false, 3.0, 120_000)
             ],
             matches(&market_matching_queue.matches)
         );
 
         assert_eq!(0_u64, order.stake_unmatched);
-        assert_eq!(360_u64, order.payout);
+        assert_eq!(360_000_u64, order.payout);
     }
 }
 

--- a/programs/monaco_protocol/src/instructions/matching/on_order_creation.rs
+++ b/programs/monaco_protocol/src/instructions/matching/on_order_creation.rs
@@ -58,57 +58,57 @@ fn match_for_order(
         };
         let stake_matched = liquidity_value.min(order.stake_unmatched);
 
-        if stake_matched > 0_u64 {
-            if liquidity.sources.is_empty() {
-                // direct match
-                market_matching_queue
-                    .matches
-                    .enqueue(OrderMatch::maker(
-                        !order.for_outcome,
-                        order.market_outcome_index,
-                        liquidity.price,
-                        stake_matched,
-                    ))
-                    .ok_or(MatchingQueueIsFull)?;
-            } else {
-                // cross match
-                for liquidity_source in &liquidity.sources {
-                    let liquidity_source_stake_matched = calculate_stake_cross(
-                        stake_matched,
-                        liquidity.price,
-                        liquidity_source.price,
-                    );
-                    market_matching_queue
-                        .matches
-                        .enqueue(OrderMatch::maker(
-                            order.for_outcome,
-                            liquidity_source.outcome,
-                            liquidity_source.price,
-                            liquidity_source_stake_matched,
-                        ))
-                        .ok_or(MatchingQueueIsFull)?;
-                }
-            }
+        // record it for removals later
+        order_matches.push((liquidity.price, liquidity.sources.clone(), stake_matched));
 
-            // record taker match
+        if stake_matched == 0_u64 {
+            continue;
+        }
+
+        if liquidity.sources.is_empty() {
+            // direct match
             market_matching_queue
                 .matches
-                .enqueue(OrderMatch::taker(
-                    *order_pk,
-                    order.for_outcome,
+                .enqueue(OrderMatch::maker(
+                    !order.for_outcome,
                     order.market_outcome_index,
                     liquidity.price,
                     stake_matched,
                 ))
                 .ok_or(MatchingQueueIsFull)?;
-
-            // this needs to happen in the loop
-            order
-                .match_stake_unmatched(stake_matched, liquidity.price)
-                .map_err(|_| CoreError::MatchingPayoutAmountError)?;
+        } else {
+            // cross match
+            for liquidity_source in &liquidity.sources {
+                let liquidity_source_stake_matched =
+                    calculate_stake_cross(stake_matched, liquidity.price, liquidity_source.price);
+                market_matching_queue
+                    .matches
+                    .enqueue(OrderMatch::maker(
+                        order.for_outcome,
+                        liquidity_source.outcome,
+                        liquidity_source.price,
+                        liquidity_source_stake_matched,
+                    ))
+                    .ok_or(MatchingQueueIsFull)?;
+            }
         }
 
-        order_matches.push((liquidity.price, liquidity.sources.clone(), stake_matched));
+        // record taker match
+        market_matching_queue
+            .matches
+            .enqueue(OrderMatch::taker(
+                *order_pk,
+                order.for_outcome,
+                order.market_outcome_index,
+                liquidity.price,
+                stake_matched,
+            ))
+            .ok_or(MatchingQueueIsFull)?;
+
+        // this needs to happen in the loop
+        order
+            .match_stake_unmatched(stake_matched, liquidity.price)
+            .map_err(|_| CoreError::MatchingPayoutAmountError)?;
     }
 
     // remove matched liquidity

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -5,7 +5,7 @@ use crate::error::CoreError;
 use crate::instructions::market::move_market_to_inplay;
 use crate::instructions::{market_position, matching, transfer};
 use crate::state::market_account::MarketStatus;
-use crate::state::market_liquidities::LiquiditySource;
+use crate::state::market_liquidities::{LiquiditySource, MarketLiquidities};
 use crate::state::order_account::*;
 
 pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
@@ -28,6 +28,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
 
     let market = &mut ctx.accounts.market;
     let market_liquidities = &mut ctx.accounts.market_liquidities;
+    let market_matching_queue = &ctx.accounts.market_matching_queue;
 
     // if market is inplay, but the inplay flag hasn't been flipped yet, do it now
     // and zero liquidities before cancelling the order if that's what the market is
@@ -36,10 +37,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
         move_market_to_inplay(market, market_liquidities)?;
     }
 
-    ctx.accounts.order.void_stake_unmatched();
-
-    let market_matching_queue = &ctx.accounts.market_matching_queue;
-    let order = &ctx.accounts.order;
+    order.void_stake_unmatched();
 
     // remove from matching pool
     let removed_from_queue = matching::matching_pool::update_on_cancel(
@@ -50,35 +48,11 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
     )?;
 
     // update liquidity if the order was still present in the matching pool
+    let update_derived_liquidity = false; // flag indicating removal of cross liquidity
     if removed_from_queue {
         match order.for_outcome {
-            true => {
-                market_liquidities
-                    .remove_liquidity_for(
-                        order.market_outcome_index,
-                        order.expected_price,
-                        order.voided_stake,
-                    )
-                    .map_err(|_| CoreError::CancelOrderNotCancellable)?;
-
-                let liquidity_source =
-                    LiquiditySource::new(order.market_outcome_index, order.expected_price);
-                market_liquidities.update_all_cross_liquidity_against(&liquidity_source);
-            }
-
-            false => {
-                market_liquidities
-                    .remove_liquidity_against(
-                        order.market_outcome_index,
-                        order.expected_price,
-                        order.voided_stake,
-                    )
-                    .map_err(|_| CoreError::CancelOrderNotCancellable)?;
-
-                let liquidity_source =
-                    LiquiditySource::new(order.market_outcome_index, order.expected_price);
-                market_liquidities.update_all_cross_liquidity_for(&liquidity_source);
-            }
+            true => remove_liquidity_for(market_liquidities, order, update_derived_liquidity)?,
+            false => remove_liquidity_against(market_liquidities, order, update_derived_liquidity)?,
         }
     }
 
@@ -99,6 +73,54 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
         ctx.accounts
             .order
             .close(ctx.accounts.payer.to_account_info())?;
+    }
+
+    Ok(())
+}
+
+fn remove_liquidity_for(
+    market_liquidities: &mut MarketLiquidities,
+    order: &Order,
+    update_derived_liquidity: bool,
+) -> Result<()> {
+    market_liquidities
+        .remove_liquidity_for(
+            order.market_outcome_index,
+            order.expected_price,
+            order.voided_stake,
+        )
+        .map_err(|_| CoreError::CancelOrderNotCancellable)?;
+
+    // disabled in production, but left in for further testing
+    // compute cost of this operation grows linear with the number of liquidity points
+    if update_derived_liquidity {
+        let liquidity_source =
+            LiquiditySource::new(order.market_outcome_index, order.expected_price);
+        market_liquidities.update_all_cross_liquidity_against(&liquidity_source);
+    }
+
+    Ok(())
+}
+
+fn remove_liquidity_against(
+    market_liquidities: &mut MarketLiquidities,
+    order: &Order,
+    update_derived_liquidity: bool,
+) -> Result<()> {
+    market_liquidities
+        .remove_liquidity_against(
+            order.market_outcome_index,
+            order.expected_price,
+            order.voided_stake,
+        )
+        .map_err(|_| CoreError::CancelOrderNotCancellable)?;
+
+    // disabled in production, but left in for further testing
+    // compute cost of this operation grows linear with the number of liquidity points
+    if update_derived_liquidity {
+        let liquidity_source =
+            LiquiditySource::new(order.market_outcome_index, order.expected_price);
+        market_liquidities.update_all_cross_liquidity_for(&liquidity_source);
     }
 
     Ok(())

--- a/programs/monaco_protocol/src/state/market_liquidities.rs
+++ b/programs/monaco_protocol/src/state/market_liquidities.rs
@@ -157,6 +157,9 @@ impl MarketLiquidities {
         amount / 1000 * 1000 // erase 3 last digits, so we don't have rounding on match
     }
 
+    // recalculates cross liquidity for a given sources
+    // this method does not validate parameters so value returned might not be real
+    // assumption is that all (n-1) different sources were passed for the n-outcome market and the price is of the n-th outcome
     pub fn update_cross_liquidity_for(&mut self, sources: &[LiquiditySource]) {
         // silly way of detecting which outcome is supposed to be updated
         // sum of all the outcomes minus sum of all provided ones equals the one we want
@@ -180,6 +183,9 @@ impl MarketLiquidities {
         }
     }
 
+    // recalculates cross liquidity for a given sources
+    // this method does not validate parameters so value returned might not be real
+    // assumption is that all (n-1) different sources were passed for the n-outcome market and the price is of the n-th outcome
     pub fn update_cross_liquidity_against(&mut self, sources: &[LiquiditySource]) {
         // silly way of detecting which outcome is supposed to be updated
         // sum of all the outcomes minus sum of all provided ones equals the one we want
@@ -235,6 +241,9 @@ impl MarketLiquidities {
         }
     }
 
+    // recalculates all existing cross liquidities for a given source
+    // removes elements with zero amount, but does NOT add new ones
+    // assumption is that all  existing cross liquidities are correct
     pub fn update_all_cross_liquidity_for(&mut self, liquidity_source: &LiquiditySource) {
         let indexed_liquidity_amounts = self
             .liquidities_for
@@ -259,6 +268,9 @@ impl MarketLiquidities {
         }
     }
 
+    // recalculates all existing cross liquidities for a given source
+    // removes elements with zero amount, but does NOT add new ones
+    // assumption is that all  existing cross liquidities are correct
     pub fn update_all_cross_liquidity_against(&mut self, liquidity_source: &LiquiditySource) {
         let indexed_liquidity_amounts = self
             .liquidities_against

--- a/programs/monaco_protocol/src/state/market_liquidities.rs
+++ b/programs/monaco_protocol/src/state/market_liquidities.rs
@@ -124,7 +124,7 @@ impl MarketLiquidities {
     // this method does not validate parameters so value returned might not be real
     // assumption is that all (n-1) different sources were passed for the n-outcome market and the price is of the n-th outcome
     pub fn get_cross_liquidity_for(&self, sources: &[LiquiditySource], price: f64) -> u64 {
-        calculate_stake_from_payout(
+        let amount = calculate_stake_from_payout(
             sources
                 .iter()
                 .map(|liquidity_source| {
@@ -135,13 +135,14 @@ impl MarketLiquidities {
                 .min()
                 .unwrap_or(0_u64),
             price,
-        )
+        );
+        amount / 1000 * 1000 // erase 3 last digits, so we don't have rounding on match
     }
 
     // this method does not validate parameters so value returned might not be real
     // assumption is that all (n-1) different sources were passed for the n-outcome market and the price is of the n-th outcome
     pub fn get_cross_liquidity_against(&self, sources: &[LiquiditySource], price: f64) -> u64 {
-        calculate_stake_from_payout(
+        let amount = calculate_stake_from_payout(
             sources
                 .iter()
                 .map(|liquidity_source| {
@@ -152,7 +153,8 @@ impl MarketLiquidities {
                 .min()
                 .unwrap_or(0_u64),
             price,
-        )
+        );
+        amount / 1000 * 1000 // erase 3 last digits, so we don't have rounding on match
     }
 
     pub fn update_cross_liquidity_for(&mut self, sources: &[LiquiditySource]) {
@@ -485,19 +487,19 @@ mod tests {
         let sources01 = [LiquiditySource::new(0, 2.8), LiquiditySource::new(1, 2.8)];
         let mut mls = mock_market_liquidities(Pubkey::default());
 
-        mls.add_liquidity_for(0, 2.8, 5).unwrap();
-        mls.add_liquidity_for(0, 2.8, 5).unwrap();
-        mls.add_liquidity_for(0, 2.9, 15).unwrap();
-        mls.add_liquidity_for(1, 2.8, 20).unwrap();
-        mls.add_liquidity_for(2, 2.8, 25).unwrap();
-        mls.add_liquidity_for(2, 3.5, 30).unwrap();
+        mls.add_liquidity_for(0, 2.8, 5_000).unwrap();
+        mls.add_liquidity_for(0, 2.8, 5_000).unwrap();
+        mls.add_liquidity_for(0, 2.9, 15_000).unwrap();
+        mls.add_liquidity_for(1, 2.8, 20_000).unwrap();
+        mls.add_liquidity_for(2, 2.8, 25_000).unwrap();
+        mls.add_liquidity_for(2, 3.5, 30_000).unwrap();
 
-        mls.add_liquidity_against(0, 2.8, 5).unwrap();
-        mls.add_liquidity_against(0, 2.8, 5).unwrap();
-        mls.add_liquidity_against(0, 2.9, 15).unwrap();
-        mls.add_liquidity_against(1, 2.8, 20).unwrap();
-        mls.add_liquidity_against(2, 2.8, 25).unwrap();
-        mls.add_liquidity_against(2, 3.5, 30).unwrap();
+        mls.add_liquidity_against(0, 2.8, 5_000).unwrap();
+        mls.add_liquidity_against(0, 2.8, 5_000).unwrap();
+        mls.add_liquidity_against(0, 2.9, 15_000).unwrap();
+        mls.add_liquidity_against(1, 2.8, 20_000).unwrap();
+        mls.add_liquidity_against(2, 2.8, 25_000).unwrap();
+        mls.add_liquidity_against(2, 3.5, 30_000).unwrap();
 
         mls.update_cross_liquidity_for(&sources01);
         mls.update_cross_liquidity_against(&sources01);
@@ -505,24 +507,24 @@ mod tests {
         // the order of the results is important
         assert_eq!(
             vec![
-                mock_liquidity(0, 2.8, 10),
-                mock_liquidity(0, 2.9, 15),
-                mock_liquidity(1, 2.8, 20),
-                mock_liquidity(2, 2.8, 25),
-                mock_liquidity(2, 3.5, 30),
-                mock_liquidity_with_sources(2, 3.5, &sources01, 8),
+                mock_liquidity(0, 2.8, 10_000),
+                mock_liquidity(0, 2.9, 15_000),
+                mock_liquidity(1, 2.8, 20_000),
+                mock_liquidity(2, 2.8, 25_000),
+                mock_liquidity(2, 3.5, 30_000),
+                mock_liquidity_with_sources(2, 3.5, &sources01, 8_000),
             ],
             mls.liquidities_for
         );
         // the order of the results is important
         assert_eq!(
             vec![
-                mock_liquidity(2, 3.5, 30),
-                mock_liquidity_with_sources(2, 3.5, &sources01, 8),
-                mock_liquidity(2, 2.8, 25),
-                mock_liquidity(1, 2.8, 20),
-                mock_liquidity(0, 2.9, 15),
-                mock_liquidity(0, 2.8, 10),
+                mock_liquidity(2, 3.5, 30_000),
+                mock_liquidity_with_sources(2, 3.5, &sources01, 8_000),
+                mock_liquidity(2, 2.8, 25_000),
+                mock_liquidity(1, 2.8, 20_000),
+                mock_liquidity(0, 2.9, 15_000),
+                mock_liquidity(0, 2.8, 10_000),
             ],
             mls.liquidities_against
         );
@@ -549,28 +551,28 @@ mod tests {
         let sources2 = [LiquiditySource::new(0, 3.0), LiquiditySource::new(1, 2.7)];
 
         let mut mls: MarketLiquidities = mock_market_liquidities(Pubkey::default());
-        mls.add_liquidity_against(0, 2.700, 100).unwrap();
-        mls.add_liquidity_against(1, 3.000, 90).unwrap();
-        mls.add_liquidity_against(0, 3.000, 45).unwrap();
-        mls.add_liquidity_against(1, 2.700, 50).unwrap();
+        mls.add_liquidity_against(0, 2.700, 100_000).unwrap();
+        mls.add_liquidity_against(1, 3.000, 90_000).unwrap();
+        mls.add_liquidity_against(0, 3.000, 45_000).unwrap();
+        mls.add_liquidity_against(1, 2.700, 50_000).unwrap();
 
         mls.update_cross_liquidity_for(&sources1);
         mls.update_cross_liquidity_for(&sources2);
 
         assert_eq!(
             vec![
-                mock_liquidity_with_sources(2, 3.375, &sources1, 80,),
-                mock_liquidity_with_sources(2, 3.375, &sources2, 40,),
+                mock_liquidity_with_sources(2, 3.375, &sources1, 80_000,),
+                mock_liquidity_with_sources(2, 3.375, &sources2, 40_000,),
             ],
             mls.liquidities_for
         );
 
-        mls.remove_liquidity_against(0, 2.700, 100).unwrap();
+        mls.remove_liquidity_against(0, 2.700, 100_000).unwrap();
         mls.update_cross_liquidity_for(&sources1);
         mls.update_cross_liquidity_for(&sources2);
 
         assert_eq!(
-            vec![mock_liquidity_with_sources(2, 3.375, &sources2, 40,),],
+            vec![mock_liquidity_with_sources(2, 3.375, &sources2, 40_000,),],
             mls.liquidities_for
         );
     }
@@ -581,28 +583,28 @@ mod tests {
         let sources2 = [LiquiditySource::new(0, 3.0), LiquiditySource::new(1, 2.7)];
 
         let mut mls: MarketLiquidities = mock_market_liquidities(Pubkey::default());
-        mls.add_liquidity_for(0, 2.700, 100).unwrap();
-        mls.add_liquidity_for(1, 3.000, 90).unwrap();
-        mls.add_liquidity_for(0, 3.000, 45).unwrap();
-        mls.add_liquidity_for(1, 2.700, 50).unwrap();
+        mls.add_liquidity_for(0, 2.700, 100_000).unwrap();
+        mls.add_liquidity_for(1, 3.000, 90_000).unwrap();
+        mls.add_liquidity_for(0, 3.000, 45_000).unwrap();
+        mls.add_liquidity_for(1, 2.700, 50_000).unwrap();
 
         mls.update_cross_liquidity_against(&sources1);
         mls.update_cross_liquidity_against(&sources2);
 
         assert_eq!(
             vec![
-                mock_liquidity_with_sources(2, 3.375, &sources1, 80,),
-                mock_liquidity_with_sources(2, 3.375, &sources2, 40,),
+                mock_liquidity_with_sources(2, 3.375, &sources1, 80_000,),
+                mock_liquidity_with_sources(2, 3.375, &sources2, 40_000,),
             ],
             mls.liquidities_against
         );
 
-        mls.remove_liquidity_for(0, 2.700, 100).unwrap();
+        mls.remove_liquidity_for(0, 2.700, 100_000).unwrap();
         mls.update_cross_liquidity_against(&sources1);
         mls.update_cross_liquidity_against(&sources2);
 
         assert_eq!(
-            vec![mock_liquidity_with_sources(2, 3.375, &sources2, 40,),],
+            vec![mock_liquidity_with_sources(2, 3.375, &sources2, 40_000,),],
             mls.liquidities_against
         );
     }
@@ -710,9 +712,9 @@ mod update_all_cross_liquidity {
     fn test_for() {
         let market_pk = Pubkey::new_unique();
         let mut mls = mock_market_liquidities(market_pk);
-        mls.add_liquidity_for(0, 3.0, 100).unwrap();
+        mls.add_liquidity_for(0, 3.0, 100_000).unwrap();
         for price in [3.5, 4.0, 4.5] {
-            mls.add_liquidity_for(1, price, 100).unwrap();
+            mls.add_liquidity_for(1, price, 100_000).unwrap();
             mls.update_cross_liquidity_against(&[
                 LiquiditySource::new(0, 3.0),
                 LiquiditySource::new(1, price),
@@ -721,10 +723,10 @@ mod update_all_cross_liquidity {
 
         assert_eq!(
             vec![
-                mock_liquidity(0, 3.0, 100),
-                mock_liquidity(1, 3.5, 100),
-                mock_liquidity(1, 4.0, 100),
-                mock_liquidity(1, 4.5, 100),
+                mock_liquidity(0, 3.0, 100_000),
+                mock_liquidity(1, 3.5, 100_000),
+                mock_liquidity(1, 4.0, 100_000),
+                mock_liquidity(1, 4.5, 100_000),
             ],
             mls.liquidities_for
         );
@@ -735,14 +737,14 @@ mod update_all_cross_liquidity {
 
         assert_eq!(
             vec![
-                mock_liquidity_with_sources(2, 2.625, &sources1, 114),
-                mock_liquidity_with_sources(2, 2.4, &sources2, 125),
-                mock_liquidity_with_sources(2, 2.25, &sources3, 133),
+                mock_liquidity_with_sources(2, 2.625, &sources1, 114_000),
+                mock_liquidity_with_sources(2, 2.4, &sources2, 125_000),
+                mock_liquidity_with_sources(2, 2.25, &sources3, 133_000),
             ],
             mls.liquidities_against
         );
 
-        mls.remove_liquidity_for(0, 3.0, 100).unwrap();
+        mls.remove_liquidity_for(0, 3.0, 100_000).unwrap();
         mls.update_all_cross_liquidity_against(&LiquiditySource::new(0, 3.0));
 
         assert_eq!(
@@ -755,9 +757,9 @@ mod update_all_cross_liquidity {
     fn test_against() {
         let market_pk = Pubkey::new_unique();
         let mut mls = mock_market_liquidities(market_pk);
-        mls.add_liquidity_against(0, 3.0, 100).unwrap();
+        mls.add_liquidity_against(0, 3.0, 100_000).unwrap();
         for price in [3.5, 4.0, 4.5] {
-            mls.add_liquidity_against(1, price, 100).unwrap();
+            mls.add_liquidity_against(1, price, 100_000).unwrap();
             mls.update_cross_liquidity_for(&[
                 LiquiditySource::new(0, 3.0),
                 LiquiditySource::new(1, price),
@@ -766,10 +768,10 @@ mod update_all_cross_liquidity {
 
         assert_eq!(
             vec![
-                mock_liquidity(1, 4.5, 100),
-                mock_liquidity(1, 4.0, 100),
-                mock_liquidity(1, 3.5, 100),
-                mock_liquidity(0, 3.0, 100),
+                mock_liquidity(1, 4.5, 100_000),
+                mock_liquidity(1, 4.0, 100_000),
+                mock_liquidity(1, 3.5, 100_000),
+                mock_liquidity(0, 3.0, 100_000),
             ],
             mls.liquidities_against
         );
@@ -780,14 +782,14 @@ mod update_all_cross_liquidity {
 
         assert_eq!(
             vec![
-                mock_liquidity_with_sources(2, 2.25, &sources3, 133),
-                mock_liquidity_with_sources(2, 2.4, &sources2, 125),
-                mock_liquidity_with_sources(2, 2.625, &sources1, 114),
+                mock_liquidity_with_sources(2, 2.25, &sources3, 133_000),
+                mock_liquidity_with_sources(2, 2.4, &sources2, 125_000),
+                mock_liquidity_with_sources(2, 2.625, &sources1, 114_000),
             ],
             mls.liquidities_for
         );
 
-        mls.remove_liquidity_against(0, 3.0, 100).unwrap();
+        mls.remove_liquidity_against(0, 3.0, 100_000).unwrap();
         mls.update_all_cross_liquidity_for(&LiquiditySource::new(0, 3.0));
 
         assert_eq!(

--- a/programs/monaco_protocol/src/state/market_liquidities.rs
+++ b/programs/monaco_protocol/src/state/market_liquidities.rs
@@ -233,6 +233,52 @@ impl MarketLiquidities {
         }
     }
 
+    pub fn update_all_cross_liquidity_for(&mut self, liquidity_source: &LiquiditySource) {
+        let indexed_liquidity_amounts = self
+            .liquidities_for
+            .iter()
+            .enumerate()
+            .filter(|(_, liquidity)| liquidity.sources.contains(liquidity_source))
+            .map(|(index, liquidity)| {
+                (
+                    index,
+                    self.get_cross_liquidity_for(&liquidity.sources, liquidity.price),
+                )
+            })
+            .collect::<Vec<(usize, u64)>>();
+
+        for (index, liquidity_amount) in indexed_liquidity_amounts {
+            if liquidity_amount == 0 {
+                self.liquidities_for.remove(index);
+            } else {
+                self.liquidities_for[index].liquidity = liquidity_amount;
+            }
+        }
+    }
+
+    pub fn update_all_cross_liquidity_against(&mut self, liquidity_source: &LiquiditySource) {
+        let indexed_liquidity_amounts = self
+            .liquidities_against
+            .iter()
+            .enumerate()
+            .filter(|(_, liquidity)| liquidity.sources.contains(liquidity_source))
+            .map(|(index, liquidity)| {
+                (
+                    index,
+                    self.get_cross_liquidity_against(&liquidity.sources, liquidity.price),
+                )
+            })
+            .collect::<Vec<(usize, u64)>>();
+
+        for (index, liquidity_amount) in indexed_liquidity_amounts {
+            if liquidity_amount == 0 {
+                self.liquidities_against.remove(index);
+            } else {
+                self.liquidities_against[index].liquidity = liquidity_amount;
+            }
+        }
+    }
+
     pub fn remove_liquidity_for(&mut self, outcome: u16, price: f64, liquidity: u64) -> Result<()> {
         let liquidities = &mut self.liquidities_for;
         let sorter = Self::sorter_for(outcome, price, &[]);

--- a/tests/order/matching_orders_02.ts
+++ b/tests/order/matching_orders_02.ts
@@ -291,7 +291,17 @@ describe("Order Matching: Cross Liquidity", () => {
 
     // validate expected liquidity (cancellation does not remove cross liquidity)
     assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
-      liquiditiesAgainst: [],
+      liquiditiesAgainst: [
+        {
+          liquidity: 0.006,
+          outcome: 2,
+          price: 3.375,
+          sources: [
+            { outcome: 0, price: 2.7 },
+            { outcome: 1, price: 3 },
+          ],
+        },
+      ],
       liquiditiesFor: [{ liquidity: 0.009, outcome: 1, price: 3, sources: [] }],
     });
 

--- a/tests/order/matching_orders_02.ts
+++ b/tests/order/matching_orders_02.ts
@@ -39,7 +39,7 @@ describe("Order Matching: Cross Liquidity", () => {
     assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
       liquiditiesAgainst: [
         {
-          liquidity: 0.006_4,
+          liquidity: 0.006,
           outcome: 2,
           price: 3.375,
           sources: [
@@ -69,7 +69,7 @@ describe("Order Matching: Cross Liquidity", () => {
     assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
       liquiditiesAgainst: [
         {
-          liquidity: 0.001_4,
+          liquidity: 0.001,
           outcome: 2,
           price: 3.375,
           sources: [
@@ -155,7 +155,7 @@ describe("Order Matching: Cross Liquidity", () => {
     assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
       liquiditiesAgainst: [
         {
-          liquidity: 0.001_4,
+          liquidity: 0.001,
           outcome: 2,
           price: 3.375,
           sources: [
@@ -291,17 +291,7 @@ describe("Order Matching: Cross Liquidity", () => {
 
     // validate expected liquidity (cancellation does not remove cross liquidity)
     assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
-      liquiditiesAgainst: [
-        {
-          liquidity: 0.006_4,
-          outcome: 2,
-          price: 3.375,
-          sources: [
-            { outcome: 0, price: 2.7 },
-            { outcome: 1, price: 3 },
-          ],
-        },
-      ],
+      liquiditiesAgainst: [],
       liquiditiesFor: [{ liquidity: 0.009, outcome: 1, price: 3, sources: [] }],
     });
 

--- a/tests/order/matching_orders_02.ts
+++ b/tests/order/matching_orders_02.ts
@@ -255,6 +255,132 @@ describe("Order Matching: Cross Liquidity", () => {
       [[1.009563, 0.994375, 0.995, 0.001062], 3],
     );
   });
+
+  it("after cancellation", async () => {
+    const PRICES = [2.7, 3.0, 3.3];
+    const [purchaserA, purchaserB, purchaserC, market] = await Promise.all([
+      createWalletWithBalance(monaco.provider),
+      createWalletWithBalance(monaco.provider),
+      createWalletWithBalance(monaco.provider),
+      monaco.createMarket(["A", "B", "C"], PRICES),
+    ]);
+    await market.open(true);
+
+    await Promise.all([
+      market.airdrop(purchaserA, 1),
+      market.airdrop(purchaserB, 1),
+      market.airdrop(purchaserC, 1),
+    ]);
+
+    // orders
+    const orderA = await market.forOrder(0, 0.008, PRICES[0], purchaserA);
+    const orderB = await market.forOrder(1, 0.009, PRICES[1], purchaserB);
+
+    // cross liquidities
+    await market.updateMarketLiquiditiesWithCrossLiquidity(
+      true,
+      [
+        { outcome: 0, price: PRICES[0] },
+        { outcome: 1, price: PRICES[1] },
+      ],
+      { outcome: 2, price: 3.375 },
+    );
+
+    // cancel one of the sources
+    await market.cancel(orderA, purchaserA);
+
+    // validate expected liquidity (cancellation does not remove cross liquidity)
+    assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
+      liquiditiesAgainst: [
+        {
+          liquidity: 0.006_4,
+          outcome: 2,
+          price: 3.375,
+          sources: [
+            { outcome: 0, price: 2.7 },
+            { outcome: 1, price: 3 },
+          ],
+        },
+      ],
+      liquiditiesFor: [{ liquidity: 0.009, outcome: 1, price: 3, sources: [] }],
+    });
+
+    // match cross liquidity
+    const orderC = await market.forOrder(2, 0.005, PRICES[2], purchaserC);
+    await market.processMatchingQueue();
+
+    // validate expected liquidity (match attempt does remove cross liquidity)
+    assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
+      liquiditiesAgainst: [],
+      liquiditiesFor: [
+        { liquidity: 0.009, outcome: 1, price: 3, sources: [] },
+        { liquidity: 0.005, outcome: 2, price: 3.3, sources: [] },
+      ],
+    });
+    assert.deepEqual(
+      await Promise.all([
+        //getOrderLocal(orderA), // outcome 0
+        getOrderLocal(orderB), // outcome 1
+        getOrderLocal(orderC), // outcome 2
+      ]),
+      [
+        {
+          payout: 0,
+          price: 3,
+          stake: 0.009,
+          stakeUnmatched: 0.009,
+          stakeVoided: 0,
+        },
+        {
+          payout: 0,
+          price: 3.3,
+          stake: 0.005,
+          stakeUnmatched: 0.005,
+          stakeVoided: 0,
+        },
+      ],
+    );
+    assert.deepEqual(
+      await Promise.all([
+        market.getMarketPosition(purchaserA),
+        market.getTokenBalance(purchaserA),
+        market.getMarketPosition(purchaserB),
+        market.getTokenBalance(purchaserB),
+        market.getMarketPosition(purchaserC),
+        market.getTokenBalance(purchaserC),
+        market.getEscrowBalance(),
+      ]),
+      [
+        { matched: [0, 0, 0], unmatched: [0, 0, 0] },
+        1,
+        { matched: [0, 0, 0], unmatched: [0.009, 0, 0.009] },
+        0.991,
+        { matched: [0, 0, 0], unmatched: [0.005, 0.005, 0] },
+        0.995,
+        0.014,
+      ],
+    );
+
+    // Settlement before commission
+    await market.settle(0);
+    await market.settleMarketPositionForPurchaser(purchaserA.publicKey, false);
+    await market.settleMarketPositionForPurchaser(purchaserB.publicKey, false);
+    await market.settleMarketPositionForPurchaser(purchaserC.publicKey, false);
+    // await market.settleOrder(orderA); canceled
+    await market.settleOrder(orderB);
+    await market.settleOrder(orderC);
+
+    const balances = await Promise.all([
+      market.getTokenBalance(purchaserA),
+      market.getTokenBalance(purchaserB),
+      market.getTokenBalance(purchaserC),
+      market.getEscrowBalance(),
+    ]);
+    assert.deepEqual(
+      [balances, balances.reduce((sum, current) => sum + current, 0)],
+      [[1, 1, 1, 0], 3],
+    );
+  });
 });
 
 async function getOrderLocal(orderPk: PublicKey) {


### PR DESCRIPTION
Changes:
* rounding down cross liquidity amount bellow 4th digit (zeroing the 3 last digits) - this is to avoid rounding of stake amounts on match on reverse calculation from cross liquidity to source liquidities (example: `10,000@3.0 + 10,000@4.5 = 13,33(3)@2.25` which is rounded to `13,000`)
* add `update_all_cross_liquidity_for` and `update_all_cross_liquidity_against` to do what they say on cancelation - however due to concerns of cost of them leaving them disabled for further investigation